### PR TITLE
Mesos 0.25.0-rc distribution image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For details and docs - see https://github.com/phusion/baseimage-docker#getting_started
+
+FROM ubuntu:14.04
+
+CMD ["/sbin/my_init"]
+
+ENV HOME /root
+
+# Uncomment these lines and comment the section underneath to allow faster
+# rebuilds when making changes to the scripts.
+# The early scripts take a long time to run but change infrequently so
+# putting them on a their own lines allow developers to take advantage of
+# Docker's layer caching. The downside is much larger images.
+#ADD /image/buildconfig /build/buildconfig
+#ADD /image/base.sh /build/base.sh
+#RUN /build/base.sh
+#ADD /image/install.sh /build/install.sh
+#RUN /build/install.sh
+#ADD /image/cleanup.sh /build/cleanup.sh
+#RUN /build/cleanup.sh
+
+# Comment these lines out if using the developer-focused alternative instead.
+ADD /image /build
+RUN /build/base.sh && \
+    /build/install.sh && \
+    /build/cleanup.sh
+

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,15 @@ BUILD_DIR=build_calico_mesos
 PYCALICO=$(wildcard $(BUILD_DIR)/libcalico/calico_containers/pycalico/*.py)
 CALICO_MESOS=$(wildcard $(SRCDIR)/calico_mesos.py)
 
-binary: dist/calico_isolator
+binary: dist/calico_mesos
 
-# Create the image that builds calico_isolator
+# Create the image that builds calico_mesos
 calico_mesos_builder.created: $(BUILD_DIR) $(PYCALICO)
 	cd build_calico_mesos; docker build -t calico/mesos-builder .
 	touch calico_mesos_builder.created
 
-
 # Create the binary: check code changes to source code, ensure builder is created.
-dist/calico_isolator: $(CALICO_MESOS) calico_mesos_builder.created
+dist/calico_mesos: $(CALICO_MESOS) calico_mesos_builder.created
 	mkdir -p dist
 	chmod 777 `pwd`/dist
 	
@@ -34,6 +33,13 @@ run-etcd:
 	--advertise-client-urls "http://$(LOCAL_IP_ENV):2379,http://127.0.0.1:4001" \
 	--listen-client-urls "http://0.0.0.0:2379,http://0.0.0.0:4001"
 
+mesos_calico_image.created:
+	docker build -f ./Dockerfile -t calico/mesos-calico .
+	touch mesos_calico_image.created
+
+mesos-calico.tar: mesos_calico_image.created
+	docker save --output mesos-calico.tar calico/mesos-calico
+
 ut: calico_mesos_builder.created
 	# Use the `root` user, since code coverage requires the /code directory to
 	# be writable.  It may not be writable for the `user` account inside the
@@ -43,7 +49,7 @@ ut: calico_mesos_builder.created
 	'/tmp/etcd -data-dir=/tmp/default.etcd/ >/dev/null 2>&1 & \
 	nosetests tests/unit  -c nose.cfg'
 
-ut-circle: calico_mesos_builder.created dist/calico_isolator
+ut-circle: calico_mesos_builder.created dist/calico_mesos
 	docker run \
 	-v `pwd`/calico_mesos:/code \
 	-v $(CIRCLE_TEST_REPORTS):/circle_output \
@@ -54,3 +60,11 @@ ut-circle: calico_mesos_builder.created dist/calico_isolator
 	--with-xunit --xunit-file=/circle_output/output.xml; RC=$$?;\
 	[[ ! -z "$$COVERALLS_REPO_TOKEN" ]] && coveralls || true; exit $$RC'
 
+clean:
+	-rm -f *.created
+	find . -name '*.pyc' -exec rm -f {} +
+	-rm -rf dist
+	-rm -f mesos-calico.tar
+	-docker rmi calico/mesos-calico
+	-docker rmi calico/mesos-builder
+	-docker run -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker:/var/lib/docker --rm martin/docker-cleanup-volumes

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Calico Networking in Mesos
 **Calico provides an IP-Per-Container Networking for your Mesos Cluster.**
 
+This repository contains code and examples for running [Apache Mesos][mesos] with [Project Calico][calico].
+
 Instead of the Executor sharing its Slave's networking namespace, it is instead given its own to launch applications in.  Frameworks (which are responsible for creating the Executor instances) can opt-in for calico-networking by providing [NetworkInfo](https://github.com/apache/mesos/blob/0.25.0-rc1/include/mesos/mesos.proto#L1366) in their [ContainerInfo](https://github.com/apache/mesos/blob/0.25.0-rc1/include/mesos/mesos.proto#L1458) spec. Frameworks which do not provide NetworkInfo will simply be launched with traditional networking. Communication between applications is allowed between applications with the same ["netgroup"](https://github.com/apache/mesos/blob/0.25.0-rc1/include/mesos/mesos.proto#L1389).
 
-Calico-mesos works in conjunction with [net-modules](https://github.com/mesosphere/net-modules), which provides a simple JSON abstraction layer between Calico and Mesos.
+Calico-mesos works in conjunction with [net-modules][net-modules], which provides a simple JSON abstraction layer between Calico and Mesos.
 
 For more information on how Calico works, see: [projectcalico.org/learn](http://projectcalico.org/learn) 
 
@@ -11,13 +13,19 @@ For more information on how Calico works, see: [projectcalico.org/learn](http://
 In order to utilize Calico Networking, each slave in the mesos cluster must install the following dependencies:
 - Each slave must run an instance of [calico-node](https://github.com/projectcalico/calico-docker#how-does-it-work), a packaged container of calico core services
 - Each slave must have `calicoctl`, a command line tool for easily launching the calico-node service.
-- Each slave must have [net-modules](https://github.com/mesosphere/net-modules) libraries installed
+- Each slave must have [net-modules][net-modules] libraries installed
 - Each slave must have the `calico-mesos` binary installed
 - Each slave must have a filled in `modules.json`, which points mesos to the location of `net-modules` libraries, and points `net-modules` to the `calico-mesos` binary.
 - Each slave must start the core mesos-slave process with `--modules=file:///path/to/modules.json`
 
 ## Demo
-To simulate a working Mesos cluster with Calico Networking, see [the net-modules demo](https://github.com/mesosphere/net-modules)
+We highly recommend that your first experiments with Mesos & Project Calico are downloading and running [the demo][net-modules], which uses Docker Compose to start a small Mesos cluster with Calico enabled on your desktop or laptop.
 
-## Installation
-Stay tuned (or contact us directly on [IRC](http://webchat.freenode.net/?randomnick=1&channels=%23calico&uio=d4) or [Slack](https://calicousers-slackin.herokuapp.com/)) for additional information on installing Calico on your working mesos cluster!
+## Deploying a Mesos Cluster with Calico.
+
+However, when you are ready to deploy on actual data center hardware, use [these instructions](docs/deploying.md).
+
+[calico]: http://projectcalico.org
+[mesos]: https://mesos.apache.org/
+[net-modules]: https://github.com/mesosphere/net-modules
+[docker]: https://www.docker.com/

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -93,9 +93,9 @@ Pull the Docker images.  This will take a few minutes.
 
     $ sudo docker pull jplock/zookeeper:3.4.5
     $ sudo docker pull quay.io/coreos/etcd:v2.2.0
-    $ sudo docker pull spikecurtis/mesos-calico:0.25.0-rc2
+    $ sudo docker pull calico/mesos-calico
     $ sudo docker pull mesosphere/marathon:v0.9.1
-    $ sudo docker pull calico/node:v0.7.0
+    $ sudo docker pull calico/node:v0.8.0
 
 Next, download the unit files
 
@@ -141,8 +141,8 @@ Do this for each compute host you'll use in your Mesos cluster.
 
 Pull the Docker images.  This will take a few minutes.
 
-    $ sudo docker pull spikecurtis/mesos-calico:0.25.0-rc2
-    $ sudo docker pull calico/node:v0.7.0
+    $ sudo docker pull calico/mesos-calico
+    $ sudo docker pull calico/node:v0.8.0
 
 Next, download the unit files
 
@@ -152,7 +152,7 @@ Next, download the unit files
 
 `calicoctl` is a small CLI tool to control your Calico network.  It's used to start Calico services on your compute host, as well as inspect and modify Calico configuration.
 
-    $ curl -L -O https://github.com/projectcalico/calico-docker/releases/download/v0.7.0/calicoctl
+    $ curl -L -O https://github.com/projectcalico/calico-docker/releases/download/v0.8.0/calicoctl
     $ chmod +x calicoctl
     $ sudo cp calicoctl /usr/bin/
 
@@ -197,7 +197,7 @@ Test Calico network functionality by running our test framework.  On the master 
 This will start a new shell inside the `mesos-master` container.
 
     $ cd /framework
-    $ ./calico_framework.py
+    $ python calico_framework.py
 
 The Calico framework launches a series of tasks on your Mesos cluster to verify network connectivity and network isolation are working correctly.
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,4 +1,4 @@
-# Deploying a Mesos Cluster with Calico.
+# Deploying a Dockerized Mesos Cluster with Calico.
 
 In these instructions, we will run all cluster services as [Docker][docker] containers.  This speeds deployment and will prevent pesky issues like incompatible dependencies.  The services we will need are
 
@@ -103,7 +103,7 @@ Next, download the unit files
 
 ## Zookeeper
 
-We'll use systemd to keep Zookeeper running.  Copy the unit into `/etc/systemd/system/`.  This unit file starts a Docker container running Zookeeper.
+We'll use systemd to keep Zookeeper running.  Copy the unit into `/usr/lib/systemd/system/`.  This unit file starts a Docker container running Zookeeper.
 
     $ sudo cp zookeeper.service /usr/lib/systemd/system/
     $ sudo systemctl enable zookeeper.service

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -1,0 +1,209 @@
+# Deploying a Mesos Cluster with Calico.
+
+In these instructions, we will run all cluster services as [Docker][docker] containers.  This speeds deployment and will prevent pesky issues like incompatible dependencies.  The services we will need are
+
+ * Zookeeper
+ * etcd
+ * Mesos Master
+ * Mesos Agent
+ * Calico
+ * Marathon (Mesos framework)
+
+In these brief instructions, I'll concentrate on getting Mesos and Calico up and running as quickly as possible.  This means leaving out the details of how to configure higly-available services.  Instead, we'll install Zookeeper, etcd, and the Mesos Master on the same "master" node.
+
+
+# Preparation
+
+These instructions are designed to run on CentOS/Red Hat Enterprise Linux 7, but other than the initial commands to configure Docker, should work on any Linux distribution that supports Docker 1.7+ and `systemd`.
+
+If your distribution does not support `systemd`, you will need to create initialization files for each of the services.  These should be straightforward based on the included `.service` files, but talk to us on the [Calico Users' Slack](https://calicousers-slackin.herokuapp.com/) if you want some assistance.  If you write init files for a new system, share the love!  PRs are welcome :) 
+
+## Install Docker
+
+    $ sudo yum install docker docker-selinux
+    $ sudo systemctl enable docker.service
+    $ sudo systemctl start docker.service
+
+## Verify Docker installation
+
+    $ sudo docker run hello-world
+
+*Optional:* You may also want to create a `docker` group and add your local user to the group.  This means you can drop the `sudo` in the `docker ...` commands that follow.
+
+    $ sudo groupadd docker
+    $ sudo usermod -aG docker `whoami`
+    $ sudo systemctl restart docker.service
+
+Then log out (`exit`) and log back in to pick up your new group association.  Verify your user has access to Docker without sudo
+
+    $ docker ps
+
+## Set & verify fully qualified domain name.
+
+These instructions assume each host can reach other hosts using their fully qualified domain names (FQDN).  To check the FQDN on a host use
+
+    $ hostname -f
+
+Then attempt to ping that name from other servers.
+
+Also important are that Calico and Mesos have the same view of the (non-fully-qualified) hostname.  In particular, the value returned by
+
+    $ hostname
+
+must be unique for each node in your cluster.  Both Calico and Mesos use this value to identify the host.
+
+## Configure your firewall
+
+You will either need to configure the firewalls on each node in your cluster (recommended) to allow access to the cluster services or disable it completely.  Included in this section is configuration examples for `firewalld`.  If you use a different firewall, check your documentation for how to open the listed ports.
+
+Master node(s) require
+
+| Service Name | Port/protocol     |
+|--------------|-------------------|
+| zookeeper    | 2181/tcp          |
+| mesos-master | 5050/tcp          |
+| etcd         | 2379/tcp 4001/tcp |
+| marathon     | 8080/tcp          |
+
+Example `firewalld` config
+
+    $ sudo firewall-cmd --zone=public --add-port=2181/tcp --permanent
+    $ sudo firewall-cmd --zone=public --add-port=5050/tcp --permanent
+    $ sudo firewall-cmd --zone=public --add-port=2379/tcp --permanent
+    $ sudo firewall-cmd --zone=public --add-port=4001/tcp --permanent
+    $ sudo firewall-cmd --zone=public --add-port=8080/tcp --permanent
+    $ sudo systemctl restart firewalld
+
+Agent (compute) nodes require
+
+| Service Name | Port/protocol     |
+|--------------|-------------------|
+| BIRD (BGP)   | 179/tcp           |
+| mesos-agent  | 5051/tcp          |
+
+Example `firewalld` config
+
+    $ sudo firewall-cmd --zone=public --add-port=179/tcp --permanent
+    $ sudo firewall-cmd --zone=public --add-port=5051/tcp --permanent
+    $ sudo systemctl restart firewalld
+
+# Set up Master services.
+
+Pull the Docker images.  This will take a few minutes.
+
+    $ sudo docker pull jplock/zookeeper:3.4.5
+    $ sudo docker pull quay.io/coreos/etcd:v2.2.0
+    $ sudo docker pull spikecurtis/mesos-calico:0.25.0-rc2
+    $ sudo docker pull mesosphere/marathon:v0.9.1
+    $ sudo docker pull calico/node:v0.7.0
+
+Next, download the unit files
+
+    $ wget https://github.com/projectcalico/calico-mesos/releases/0.1/units.tgz
+
+## Zookeeper
+
+We'll use systemd to keep Zookeeper running.  Copy the unit into `/etc/systemd/system/`.  This unit file starts a Docker container running Zookeeper.
+
+    $ sudo cp zookeeper.service /usr/lib/systemd/system/
+    $ sudo systemctl enable zookeeper.service
+    $ sudo systemctl start zookeeper.service
+
+## Mesos Master
+
+Create and enable the `mesos-master` unit, which starts a Docker container running Mesos.
+
+    $ sudo cp mesos-master.service /usr/lib/systemd/system/
+    $ sudo systemctl enable mesos-master.service
+    $ sudo systemctl start mesos-master.service
+
+## Etcd
+
+`etcd` needs your fully qualified domain name to start correctly.  The included
+unit file looks for this value in `/etc/sysconfig/etcd`.
+
+    $ sudo sh -c 'echo FQDN=`hostname -f` > /etc/sysconfig/etcd'
+    $ sudo cp etcd.service /usr/lib/systemd/system/
+    $ sudo systemctl enable etcd.service
+    $ sudo systemctl start etcd.service
+
+## Marathon
+
+Lastly, start Marathon, a Mesos framework you can use to start arbitrary tasks on your cluster.
+
+    $ sudo cp marathon.service /usr/lib/systemd/system/
+    $ sudo systemctl enable marathon.service
+    $ sudo systemctl start marathon.service
+
+# Set up Agent Services
+
+Do this for each compute host you'll use in your Mesos cluster.
+
+Pull the Docker images.  This will take a few minutes.
+
+    $ sudo docker pull spikecurtis/mesos-calico:0.25.0-rc2
+    $ sudo docker pull calico/node:v0.7.0
+
+Next, download the unit files
+
+    $ wget https://github.com/projectcalico/calico-mesos/releases/0.1/units.tgz
+
+## Calico
+
+`calicoctl` is a small CLI tool to control your Calico network.  It's used to start Calico services on your compute host, as well as inspect and modify Calico configuration.
+
+    $ curl -L -O https://github.com/projectcalico/calico-docker/releases/download/v0.7.0/calicoctl
+    $ chmod +x calicoctl
+    $ sudo cp calicoctl /usr/bin/
+
+You can learn more about `calicoctl` by running `calicoctl --help`.
+
+You'll need to configure Calico with the correct location of the etcd service.  In the following line, replace `masterip` with the IP address of the Master node.
+
+    $ sudo sh -c 'echo ETCD_AUTHORITY=masterip:4001 > /etc/sysconfig/calico'
+
+Then, enable the Calico service via `systemd`
+
+    $ sudo cp calico.service /usr/lib/systemd/system/
+    $ sudo systemctl enable calico.service
+    $ sudo systemctl start calico.service
+
+Verify Calico is running
+
+    $ calicoctl status
+
+## Mesos Agent
+
+The Mesos Agent uses Zookeeper to keep track of the current Mesos Master.  Use the following command to tell the Mesos Agent where to find Zookeeper.  We installed it on the same host as the Mesos Master earlier, so substitute the name or IP of that host for `zookeeperip`.
+
+    $ sudo sh -c 'echo ZK=zookeeperip > /etc/sysconfig/mesos-agent'
+
+Then, enable the Mesos Agent service
+
+    $ sudo cp mesos-agent.service /usr/lib/systemd/system/
+    $ sudo systemctl enable mesos-agent.service
+    $ sudo systemctl start mesos-agent.service
+
+# Test your cluster
+
+Verify Mesos is working and has the expected number of agents (what used to be called /slaves/ and still are in the UI).  Point your browser to the master node, port 5050 (e.g. http://mesos-master.mydomain:5050/ ).
+
+Verify that Marathon is up and available on port 8080 (e.g. http://mesos-master.mydomain:8080/ ).
+
+Test Calico network functionality by running our test framework.  On the master node
+
+    $ sudo docker exec -ti mesos-master bash
+
+This will start a new shell inside the `mesos-master` container.
+
+    $ cd /framework
+    $ ./calico_framework.py
+
+The Calico framework launches a series of tasks on your Mesos cluster to verify network connectivity and network isolation are working correctly.
+
+At time of writing Marathon still uses the old Mesos networking, rather than Calico IP-per-container networking.  We still include it so you can test backward compatibility.  Try launching some tasks.
+
+[calico]: http://projectcalico.org
+[mesos]: https://mesos.apache.org/
+[net-modules]: https://github.com/mesosphere/net-modules
+[docker]: https://www.docker.com/

--- a/docs/units/calico.service
+++ b/docs/units/calico.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Calico
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+EnvironmentFile=/etc/sysconfig/calico
+ExecStartPre=-/usr/bin/calicoctl checksystem --fix
+ExecStart=/usr/bin/calicoctl node --detach=false
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/units/etcd.service
+++ b/docs/units/etcd.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=etcd
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+EnvironmentFile=-/etc/sysconfig/etcd
+ExecStartPre=-mkdir -p /var/etcd
+ExecStartPre=-chcon -Rt svirt_sandbox_file_t /var/etcd
+ExecStartPre=-/usr/bin/docker kill etcd
+ExecStartPre=-/usr/bin/docker rm etcd
+ExecStart=/usr/bin/docker run --name etcd \
+  --net host \
+  -v /var/etcd:/data \
+  quay.io/coreos/etcd:v2.2.0 \
+  --advertise-client-urls "http://${FQDN}:2379,http://${FQDN}:4001" \
+  --listen-client-urls "http://0.0.0.0:2379,http://0.0.0.0:4001" \
+  --data-dir /data
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/units/marathon.service
+++ b/docs/units/marathon.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Mesos Master
+After=mesos-master.service docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+ExecStartPre=-/usr/bin/docker kill marathon
+ExecStartPre=-/usr/bin/docker rm marathon
+ExecStart=/usr/bin/docker run --name marathon \
+  -e MARATHON_MASTER=zk://localhost:2181/mesos/master \
+  -e MARATHON_ZK=zk://localhost:2181/marathon \
+  -e MARATHON_MAX_TASKS_PER_OFFER=32 \
+  --net host \
+  mesosphere/marathon:v0.9.1
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/units/mesos-agent.service
+++ b/docs/units/mesos-agent.service
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/docker run --name mesos-agent \
   -e ETCD_AUTHORITY=${ETCD_AUTHORITY} \
   --net host \
   --privileged \
-  spikecurtis/mesos-calico:0.25.0-rc2 /root/runagent
+  calico/mesos-calico /root/runagent
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/units/mesos-agent.service
+++ b/docs/units/mesos-agent.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Mesos Agent
+After=docker.service calico.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+EnvironmentFile=/etc/sysconfig/mesos-agent
+EnvironmentFile=/etc/sysconfig/calico
+ExecStartPre=-/usr/bin/docker kill mesos-agent
+ExecStartPre=-/usr/bin/docker rm mesos-agent
+ExecStart=/usr/bin/docker run --name mesos-agent \
+  -e MESOS_MASTER=zk://${ZK}:2181/mesos/master \
+  -e MESOS_EXECUTOR_REGISTRATION_TIMEOUT=5mins \
+  -e MESOS_CONTAINERIZERS=mesos \
+  -e MESOS_ISOLATOR=cgroups/cpu,cgroups/mem \
+  -e MESOS_LOG_DIR=/var/log \
+  -e MESOS_RESOURCES=ports(*):[31000-31100] \
+  -e MESOS_MODULES=file:///calico/modules.json \
+  -e MESOS_ISOLATION=com_mesosphere_mesos_NetworkIsolator \
+  -e MESOS_HOOKS=com_mesosphere_mesos_NetworkHook \
+  -e ETCD_AUTHORITY=${ETCD_AUTHORITY} \
+  --net host \
+  --privileged \
+  spikecurtis/mesos-calico:0.25.0-rc2 /root/runagent
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/units/mesos-master.service
+++ b/docs/units/mesos-master.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Mesos Master
+After=zookeeper.service docker.service
+Requires=zookeeper.service docker.service
+
+[Service]
+TimeoutStartSec=0
+ExecStartPre=-/usr/bin/docker kill mesos-master
+ExecStartPre=-/usr/bin/docker rm mesos-master
+ExecStart=/usr/bin/docker run --name mesos-master \
+  -e MESOS_WORK_DIR=/var/mesos \
+  -e MESOS_ZK=zk://127.0.0.1:2181/mesos/master \
+  -e MESOS_QUORUM=1 \
+  -e MESOS_LOG_DIR=/var/log \
+  --net host \
+  spikecurtis/mesos-calico:0.25.0-rc2 /usr/local/sbin/mesos-master
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/units/mesos-master.service
+++ b/docs/units/mesos-master.service
@@ -13,7 +13,7 @@ ExecStart=/usr/bin/docker run --name mesos-master \
   -e MESOS_QUORUM=1 \
   -e MESOS_LOG_DIR=/var/log \
   --net host \
-  spikecurtis/mesos-calico:0.25.0-rc2 /usr/local/sbin/mesos-master
+  calico/mesos-calico /usr/local/sbin/mesos-master
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/units/zookeeper.service
+++ b/docs/units/zookeeper.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Zookeeper
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+ExecStartPre=-/usr/bin/docker kill zookeeper
+ExecStartPre=-/usr/bin/docker rm zookeeper
+ExecStartPre=/usr/bin/docker pull jplock/zookeeper:3.4.5
+ExecStart=/usr/bin/docker run --name zookeeper -p 2181:2181 jplock/zookeeper:3.4.5
+ExecStop=/usr/bin/docker kill zookeeper
+
+[Install]
+WantedBy=multi-user.target

--- a/image/base.sh
+++ b/image/base.sh
@@ -26,4 +26,5 @@ $minimal_apt_get_install \
   libsasl2-dev                     \
   libgoogle-glog-dev               \
   libboost-dev                     \
-  libprotobuf-dev
+  libprotobuf-dev                  \
+  wget

--- a/image/base.sh
+++ b/image/base.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+source /build/buildconfig
+set -x
+
+# Upgrade all packages.
+apt-get update
+apt-get dist-upgrade -y --no-install-recommends
+
+# Determine the list of packages required for the base image.
+dpkg -l | grep ^ii | sed 's_  _\t_g' | cut -f 2 >/tmp/base.txt
+
+# Install packages that should not be removed in the cleanup processing.
+# - packages required by felix
+# - pip (which includes various setuptools package discovery).
+# apt-get install -qy \
+$minimal_apt_get_install \
+  python                           \
+  python2.7                        \
+  python-protobuf                  \
+  libsasl2-modules-gssapi-heimdal  \
+  libcurl4-nss-dev                 \
+  libtool                          \
+  libapr1-dev                      \
+  libsvn-dev                       \
+  libsasl2-dev                     \
+  libgoogle-glog-dev               \
+  libboost-dev                     \
+  libprotobuf-dev

--- a/image/buildconfig
+++ b/image/buildconfig
@@ -1,0 +1,4 @@
+# Copied from https://github.com/phusion/baseimage-docker/blob/16ccc1e40d34a4cec8975e28a6a4f1d954b408b9/image/buildconfig
+export LC_ALL=C
+export DEBIAN_FRONTEND=noninteractive
+minimal_apt_get_install='apt-get install -y --no-install-recommends'

--- a/image/cleanup.sh
+++ b/image/cleanup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+set -x
+
+# Remove extra packages using dpkg rather than apt-get - this prevents us from
+# deleting dependent packages that we still require.
+# - Remove any temporary packages installed in the install.sh script.
+# - Remove any temporary packages installed in the base.sh script.
+echo "Removing extra packages"
+grep -Fxvf  /tmp/required.txt <(dpkg -l | grep ^ii | sed 's_  _\t_g' | cut -f 2) | xargs dpkg -r --force-depends
+
+# Remove any other junk created during installation that is not required.
+apt-get clean
+rm -rf /build
+rm -rf /tmp/* /var/tmp/*
+rm -rf /var/lib/apt/lists/*
+rm -f /etc/dpkg/dpkg.cfg.d/02apt-speedup
+rm -rf /mesos
+rm -rf /net-modules

--- a/image/install.sh
+++ b/image/install.sh
@@ -63,8 +63,8 @@ cp /mesos/build/bin/*.sh /root
 
 # Isolator
 mkdir -p /net-modules
-git clone https://github.com/djosborne/net-modules.git /net-modules
-cd /net-modules && git checkout 0.25-framework
+git clone https://github.com/mesosphere/net-modules.git /net-modules
+cd /net-modules && git checkout integration/0.25
 mv /net-modules/isolator /
 cd /isolator
 
@@ -79,5 +79,7 @@ cd /isolator
 mv /build/runagent /root
 mkdir /calico
 mv /net-modules/calico/modules.json /calico/
-mv /net-modules/calico/calico_isolator /calico/
+cd /calico
+wget https://github.com/projectcalico/calico-mesos/releases/download/v0.1.1/calico_mesos
+chmod +x calico_mesos
 mv /net-modules/framework /

--- a/image/install.sh
+++ b/image/install.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+# Get the current list of required packages (this is used in the clean up
+# code to remove the temporary packages that are about to be installed).
+dpkg -l | grep ^ii | sed 's_  _\t_g' | cut -f 2 >/tmp/required.txt
+
+# Install temporary packages required for installing Mesos.
+apt-get -qy install software-properties-common # (for add-apt-repository)
+add-apt-repository ppa:george-edison55/cmake-3.x
+apt-get update -q
+apt-cache policy cmake
+apt-get -qy install \
+  build-essential                         \
+  autoconf                                \
+  automake                                \
+  cmake=3.2.2-2ubuntu2~ubuntu14.04.1~ppa1 \
+  ca-certificates                         \
+  gdb                                     \
+  wget                                    \
+  git-core                                \
+  protobuf-compiler                       \
+  make                                    \
+  libpython-dev                           \
+  python-dev                              \
+  python-setuptools                       \
+  heimdal-clients                         \
+  unzip                                   \
+  --no-install-recommends
+
+# Install the picojson headers
+wget https://raw.githubusercontent.com/kazuho/picojson/v1.3.0/picojson.h -O /usr/local/include/picojson.h
+
+# Prepare to build Mesos
+mkdir -p /mesos
+mkdir -p /tmp
+mkdir -p /usr/share/java/
+wget http://search.maven.org/remotecontent?filepath=com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar -O protobuf.jar
+mv protobuf.jar /usr/share/java/
+
+# Clone Mesos (master branch)
+git clone https://github.com/apache/mesos.git /mesos
+cd /mesos
+git checkout 0.25.0
+git log -n 1
+
+# Bootstrap
+./bootstrap
+
+# Configure
+mkdir build && cd build && ../configure --disable-java --disable-optimize --without-included-zookeeper --with-glog=/usr/local --with-protobuf=/usr --with-boost=/usr/local
+
+# Build Mesos
+make -j 2 install
+
+# Install python eggs (needed for sample framework)
+easy_install /mesos/build/src/python/dist/mesos.interface-*.egg
+easy_install /mesos/build/src/python/dist/mesos.native-*.egg
+
+# Copy start up scripts
+cp /mesos/build/bin/*.sh /root
+
+# Isolator
+mkdir -p /net-modules
+git clone https://github.com/djosborne/net-modules.git /net-modules
+cd /net-modules && git checkout 0.25-framework
+mv /net-modules/isolator /
+cd /isolator
+
+./bootstrap && \
+  rm -rf build && \
+  mkdir build && \
+  cd build && \
+  export LD_LIBRARY_PATH=LD_LIBRARY_PATH:/usr/local/lib && \
+  ../configure --with-mesos=/usr/local --with-protobuf=/usr && \
+  make all
+
+mv /build/runagent /root
+mkdir /calico
+mv /net-modules/calico/modules.json /calico/
+mv /net-modules/calico/calico_isolator /calico/
+mv /net-modules/framework /

--- a/image/runagent
+++ b/image/runagent
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Based on https://github.com/jpetazzo/dind
+
+# Ensure that all nodes in /dev/mapper correspond to mapped devices currently loaded by the device-mapper kernel driver
+dmsetup mknodes
+
+# First, make sure that cgroups are mounted correctly.
+CGROUP=/sys/fs/cgroup
+: {LOG:=stdio}
+
+[ -d $CGROUP ] ||
+	mkdir $CGROUP
+
+mountpoint -q $CGROUP ||
+	mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
+		echo "Could not make a tmpfs mount. Did you use --privileged?"
+		exit 1
+	}
+
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security
+then
+    mount -t securityfs none /sys/kernel/security || {
+        echo "Could not mount /sys/kernel/security."
+        echo "AppArmor detection and --privileged mode might break."
+    }
+fi
+
+# Mount the cgroup hierarchies exactly as they are in the parent system.
+for SUBSYS in $(cut -d: -f2 /proc/1/cgroup)
+do
+        [ -d $CGROUP/$SUBSYS ] || mkdir $CGROUP/$SUBSYS
+        mountpoint -q $CGROUP/$SUBSYS ||
+                mount -n -t cgroup -o $SUBSYS cgroup $CGROUP/$SUBSYS
+
+        # The two following sections address a bug which manifests itself
+        # by a cryptic "lxc-start: no ns_cgroup option specified" when
+        # trying to start containers withina container.
+        # The bug seems to appear when the cgroup hierarchies are not
+        # mounted on the exact same directories in the host, and in the
+        # container.
+
+        # Named, control-less cgroups are mounted with "-o name=foo"
+        # (and appear as such under /proc/<pid>/cgroup) but are usually
+        # mounted on a directory named "foo" (without the "name=" prefix).
+        # Systemd and OpenRC (and possibly others) both create such a
+        # cgroup. To avoid the aforementioned bug, we symlink "foo" to
+        # "name=foo". This shouldn't have any adverse effect.
+        echo $SUBSYS | grep -q ^name= && {
+                NAME=$(echo $SUBSYS | sed s/^name=//)
+                ln -s $SUBSYS $CGROUP/$NAME
+        }
+
+        # Likewise, on at least one system, it has been reported that
+        # systemd would mount the CPU and CPU accounting controllers
+        # (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
+        # but on a directory called "cpu,cpuacct" (note the inversion
+        # in the order of the groups). This tries to work around it.
+        [ $SUBSYS = cpuacct,cpu ] && ln -s $SUBSYS $CGROUP/cpu,cpuacct
+done
+
+# Note: as I write those lines, the LXC userland tools cannot setup
+# a "sub-container" properly if the "devices" cgroup is not in its
+# own hierarchy. Let's detect this and issue a warning.
+grep -q :devices: /proc/1/cgroup ||
+	echo "WARNING: the 'devices' cgroup should be in its own hierarchy."
+grep -qw devices /proc/1/cgroup ||
+	echo "WARNING: it looks like the 'devices' cgroup is not mounted."
+
+# Now, close extraneous file descriptors.
+pushd /proc/self/fd >/dev/null
+for FD in *
+do
+	case "$FD" in
+	# Keep stdin/stdout/stderr
+	[012])
+		;;
+	# Nuke everything else
+	*)
+		eval exec "$FD>&-"
+		;;
+	esac
+done
+popd >/dev/null
+
+# We explicitly call hostname here, since Mesos relies on the less reliable
+# solution of reverse-lookup on the IP.  Also the hostname much match what
+# Calico uses, which is obtained by the python equivalent of `hostname`
+/usr/local/sbin/mesos-slave --hostname=`hostname`


### PR DESCRIPTION
This PR is a rebased continuation of #8 

This commit introduces a Mesos distributable Docker image, with the Calico driver included.

It also documents how to manually start up a Mesos cluster
using the image and other openly available Docker images.

Note that we've hardcoded:

Mesos 0.25.0
Image name as spikecurtis/mesos-calico:0.25.0-rc2
Net-modules branch to djosbourne/0.25-framework
These should get updates to more "official" names and branches ASAP.