### PR TITLE
Remove mesos/netmodules dependency from calico rpm

### DIFF
--- a/packages/calico-mesos.spec
+++ b/packages/calico-mesos.spec
@@ -13,8 +13,6 @@ Source2:       modules.json
 Source3:       calicoctl
 
 Requires:      docker
-Requires:      mesos >= 0.25.0
-Requires:      net-modules
 
 %description
 Calico provides IP-Per-Container Networking for a Mesos Cluster.


### PR DESCRIPTION
The mesos/net-modules dependency requires the user to install the calico-mesos rpm only after they installed from the mesos/net-modules rpms. Therefore, if a user installs mesos manually, he/she cannot install calico-mesos from the rpm.