### PR TITLE
Cleaned up RPM build

### DIFF
--- a/packages/Dockerfile
+++ b/packages/Dockerfile
@@ -16,3 +16,7 @@ ADD ./sources/ /root/rpmbuild/SOURCES/
 
 # Build RPM
 ADD ./calico-mesos.spec /root/calico-mesos.spec
+
+# The rpm-builder assumes the calico_mesos binary has been volume mounted to /binary.
+# Here, it is copied into the RPM Source directory,then the RPM build is kicked off.
+CMD bash -c 'cp /binary/calico_mesos root/rpmbuild/SOURCES && rpmbuild -ba /root/calico-mesos.spec'


### PR DESCRIPTION
Split the `dist` directory into two subdirectories, one for RPMs and one for Binaries, on the basis that the output of the binary build is the input for the RPM build. keeping them as siblings in the same directory makes volume mounting difficult.