### PR TITLE
Configure unified containerizer / SSL in 0.27

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,6 +57,11 @@ Vagrant.configure("2") do |config|
       # Selinux => permissive
       host.vm.provision :shell, inline: "setenforce permissive", privileged: true
 
+      # Generate certs
+      host.vm.provision :shell, inline: "mkdir /keys", privileged: true
+      host.vm.provision :shell, inline: "openssl genrsa -f4  -out /keys/key.pem 4096", privileged: true
+      host.vm.provision :shell, inline: "openssl req -new -batch -x509  -days 365 -key /keys/key.pem -out /keys/cert.pem", privileged: true
+
       # Install docker, and load in the custom mesos-calico image
       host.vm.provision :docker
 

--- a/dockerized-mesos/config/units/marathon.service
+++ b/dockerized-mesos/config/units/marathon.service
@@ -12,7 +12,7 @@ ExecStart=/usr/bin/docker run --name marathon \
   -e MARATHON_ZK=zk://localhost:2181/marathon \
   -e MARATHON_MAX_TASKS_PER_OFFER=32 \
   --net host \
-  mesosphere/marathon:v0.9.1
+  djosborne/marathon:docker
 
 [Install]
 WantedBy=multi-user.target

--- a/dockerized-mesos/config/units/mesos-agent.service
+++ b/dockerized-mesos/config/units/mesos-agent.service
@@ -22,8 +22,10 @@ ExecStart=/usr/bin/docker run --name mesos-agent \
   -e MESOS_LOG_DIR=/var/log \
   -e MESOS_RESOURCES=ports(*):[31000-31100] \
   -e MESOS_MODULES=file:///calico/modules.json \
-  -e MESOS_ISOLATION=com_mesosphere_mesos_NetworkIsolator \
+  -e MESOS_ISOLATION=com_mesosphere_mesos_NetworkIsolator,filesystem/linux \
   -e MESOS_HOOKS=com_mesosphere_mesos_NetworkHook \
+  -e MESOS_IMAGE_PROVIDERS=docker \
+  -e MESOS_IMAGE_PROVISIONER_BACKEND=copy \
   -e ETCD_AUTHORITY=${ETCD_AUTHORITY} \
   -v /keys:/keys \
   --net host \

--- a/dockerized-mesos/config/units/mesos-agent.service
+++ b/dockerized-mesos/config/units/mesos-agent.service
@@ -10,6 +10,10 @@ EnvironmentFile=/etc/sysconfig/calico
 ExecStartPre=-/usr/bin/docker kill mesos-agent
 ExecStartPre=-/usr/bin/docker rm mesos-agent
 ExecStart=/usr/bin/docker run --name mesos-agent \
+  -e SSL_ENABLED=true \
+  -e SSL_SUPPORT_DOWNGRADE=true \
+  -e SSL_KEY_FILE=/keys/key.pem \
+  -e SSL_CERT_FILE=/keys/cert.pem \
   -e MESOS_MASTER=zk://${ZK}:2181/mesos/master \
   -e MESOS_IP=${IP} \
   -e MESOS_EXECUTOR_REGISTRATION_TIMEOUT=5mins \
@@ -21,6 +25,7 @@ ExecStart=/usr/bin/docker run --name mesos-agent \
   -e MESOS_ISOLATION=com_mesosphere_mesos_NetworkIsolator \
   -e MESOS_HOOKS=com_mesosphere_mesos_NetworkHook \
   -e ETCD_AUTHORITY=${ETCD_AUTHORITY} \
+  -v /keys:/keys \
   --net host \
   --privileged \
   calico/mesos-calico:0.27 /root/runagent

--- a/dockerized-mesos/config/units/mesos-master.service
+++ b/dockerized-mesos/config/units/mesos-master.service
@@ -9,11 +9,16 @@ EnvironmentFile=/etc/sysconfig/mesos-master
 ExecStartPre=-/usr/bin/docker kill mesos-master
 ExecStartPre=-/usr/bin/docker rm mesos-master
 ExecStart=/usr/bin/docker run --name mesos-master \
+  -e SSL_ENABLED=true \
+  -e SSL_SUPPORT_DOWNGRADE=true \
+  -e SSL_KEY_FILE=/keys/key.pem \
+  -e SSL_CERT_FILE=/keys/cert.pem \
   -e MESOS_WORK_DIR=/var/mesos \
   -e MESOS_ZK=zk://127.0.0.1:2181/mesos/master \
   -e MESOS_QUORUM=1 \
   -e MESOS_LOG_DIR=/var/log \
   -e MESOS_IP=${IP} \
+  -v /keys:/keys \
   --net host \
   calico/mesos-calico:0.27 /usr/local/sbin/mesos-master
 


### PR DESCRIPTION
Modified to use latest master build (0.27 candidate). This setup is capable of launching docker containers through marathon