### PR TITLE
Removed dependency on centos docker package 

### DIFF
--- a/packages/calico-mesos.spec
+++ b/packages/calico-mesos.spec
@@ -14,8 +14,6 @@ Source2:       modules.json
 Source3:       calicoctl
 Source4:       modules
 
-Requires:      docker
-
 %description
 Calico provides IP-Per-Container Networking for a Mesos Cluster.
 


### PR DESCRIPTION
User should now be able to install and use any docker version they want. Fixes [#753](https://github.com/projectcalico/calico-containers/issues/753)